### PR TITLE
Feature Fest Number Uno: Psychic shenannigans!

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1000,6 +1000,48 @@
 	message_admins("[X] has sent [L] this psychic message: \"[msg]\" at [ADMIN_VERBOSEJMP(X)].")
 
 // ***************************************
+// *********** Psychic Influence
+// ***************************************
+/datum/action/ability/xeno_action/psychic_influence
+	name = "Psychic Influence"
+	action_icon_state = "psychic_whisper"
+	keybinding_signals = list(
+		KEYBINDING_NORMAL = COMSIG_XENOABILITY_PSYCHIC_WHISPER,
+	)
+	use_state_flags = ABILITY_USE_LYING
+	target_flags = ABILITY_MOB_TARGET
+	
+	
+/datum/action/ability/xeno_action/psychic_influence/action_activate()
+	var/mob/living/carbon/xenomorph/X = owner
+	var/list/target_list = list()
+	for(var/mob/living/possible_target in view(WORLD_VIEW, X))
+		if(possible_target == X || !possible_target.client || isxeno(possible_target))
+			continue
+		target_list += possible_target
+
+	if(!length(target_list))
+		to_chat(X, span_warning("There's nobody nearby to influence."))
+		return
+
+	var/mob/living/L = tgui_input_list(X, "Target", "Send a Psychic Influence to whom?", target_list)
+	if(!L)
+		return
+
+	if(!X.check_state())
+		return
+
+	var/msg = stripped_input("Message:", "Psychic Influence")
+	if(!msg)
+		return
+
+	log_directed_talk(X, L, msg, LOG_SAY, "psychic influence")
+	to_chat(L, span_alien("<i>\"[msg]\"</i>"))
+	to_chat(X, span_xenonotice("We influenced: \"[msg]\" to [L]"))
+	message_admins("[X] has sent [L] this psychic influence: \"[msg]\" at [ADMIN_VERBOSEJMP(X)].")
+	
+
+// ***************************************
 // *********** Lay Egg
 // ***************************************
 /datum/action/ability/xeno_action/lay_egg

--- a/code/modules/mob/living/carbon/xenomorph/castes/baneling/castedatum_baneling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/baneling/castedatum_baneling.dm
@@ -45,6 +45,8 @@
 	// *** Abilities *** ///
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno/baneling,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/xeno_action/spawn_pod,

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
@@ -42,6 +42,8 @@
 	// *** Abilities *** ///
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/xeno_action/ready_charge/behemoth_roll,

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -60,6 +60,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/xeno_action/place_acidwell,

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -47,6 +47,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/xeno_action/ready_charge/bull_charge,

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -52,6 +52,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/cocoon,

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -44,6 +44,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/stomp,

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -51,6 +51,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/xeno_action/toggle_crest_defense,

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -42,6 +42,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/cocoon,

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -56,6 +56,8 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/cocoon,

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/castedatum_gorger.dm
@@ -50,6 +50,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain/free,
 		/datum/action/ability/activable/xeno/psychic_link,

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -57,6 +57,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/cocoon,

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -51,6 +51,8 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/silence,

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -43,6 +43,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/cocoon,

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -52,6 +52,8 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/xeno_action/place_acidwell,

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
@@ -32,6 +32,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain/free,
 		/datum/action/ability/activable/xeno/flay,

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -52,6 +52,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/cocoon,
 		/datum/action/ability/activable/xeno/plant_weeds,

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -43,6 +43,8 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/charge,

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -49,6 +49,8 @@
 	// *** Abilities *** ///
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/xeno_action/xenohide,

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -50,6 +50,8 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/corrosive_acid/drone,

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -50,6 +50,8 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/cocoon,
@@ -62,7 +64,6 @@
 		/datum/action/ability/activable/xeno/corrosive_acid,
 		/datum/action/ability/activable/xeno/psychic_cure,
 		/datum/action/ability/activable/xeno/transfer_plasma/drone,
-		/datum/action/ability/xeno_action/psychic_whisper,
 		/datum/action/ability/activable/xeno/psychic_fling,
 		/datum/action/ability/activable/xeno/unrelenting_force,
 		/datum/action/ability/xeno_action/pheromones,

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -57,6 +57,8 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/corrosive_acid,

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/castedatum_warlock.dm
@@ -26,13 +26,14 @@
 	minimap_icon = "warlock"
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/psy_crush,
 		/datum/action/ability/activable/xeno/psy_blast,
 		/datum/action/ability/activable/xeno/psychic_shield,
 		/datum/action/ability/activable/xeno/transfer_plasma/drone,
-		/datum/action/ability/xeno_action/psychic_whisper,
 	)
 
 /datum/xeno_caste/warlock/normal

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -45,6 +45,8 @@
 
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/xeno_action/toggle_agility,

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
@@ -44,6 +44,8 @@
 	// *** Abilities *** ///
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/cocoon,

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -46,6 +46,8 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/ability/xeno_action/xeno_resting,
+		/datum/action/ability/xeno_action/psychic_whisper,
+		/datum/action/ability/xeno_action/psychic_influence,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
 		/datum/action/ability/activable/xeno/blink,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A funny feature I genuinely thought would take me longer to understand; Psychic whispers as well as pychic influences for (almost) every Xenomorph-caste!

The only ones that didn't get it were the minion-castes, larvae and the Hivemind.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Roleplay, duh.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
:cl:
add: Psionic whisper and custom made psionic influence to almost all xenomorph castes
:cl:

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
