### PR TITLE
Update castedatum_puppeteer.dm

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
@@ -12,8 +12,8 @@
 	speed = -0.8
 	melee_damage = 18
 	plasma_max = 750
-	plasma_gain = 0
-	plasma_regen_limit = 0
+	plasma_gain = 25
+	plasma_regen_limit = 25
 	plasma_icon_state = "fury"
 	max_health = 365
 	upgrade_threshold = TIER_TWO_THRESHOLD


### PR DESCRIPTION
Simple change that was requested by another player on the server today. Pantsu didn't seem to object, so I thought I might as well go for it.

Enables puppeteers to generate plasma without having to maim and murder people. This change ought to be more conductive to the general non-hostile vibe the server is going for.

Was tested and worked fine. Only oddity that stands out is that puppeteers start out with more plasma than they should have until they fill their evo bar, after which it reverts to the previous limit.