### PR TITLE
Xenos in OOC Crew Manifest

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -22,6 +22,7 @@ GLOBAL_DATUM_INIT(datacore, /datum/datacore, new)
 	var/list/mar = list()
 	var/list/heads = list()
 	var/list/misc = list()
+	var/list/xeno = list()
 	var/list/isactive = list()
 	var/list/squads = list()
 	var/list/support = list()
@@ -76,6 +77,26 @@ GLOBAL_DATUM_INIT(datacore, /datum/datacore, new)
 			department = 1
 		if(!department && !(name in heads) && (rank in GLOB.jobs_regular_all))
 			misc[name] = rank
+
+	// Adds xenomorphs to the game manifest if it's being polled from the game lobby or ghosts
+	if(ooc)
+		for(var/mob/living/carbon/xenomorph/X in GLOB.xeno_mob_list)
+			var/name = X.real_name
+			var/rank = X.xeno_caste.caste_name
+			//var/squad_name = "N/A"
+
+			if(ooc)
+				var/active = 0
+				for(var/mob/M in GLOB.player_list)
+					if(M.real_name == name && M.client && M.client.inactivity <= 10 * 60 * 10)
+						active = 1
+						break
+				isactive[name] = active ? "Active" : "Inactive"
+			else
+				isactive[name] = !isdead(X)
+
+			xeno[name] = rank
+
 	if(length(heads) > 0)
 		dat += "<tr><th colspan=3>Command</th></tr>"
 		for(var/name in heads)
@@ -110,6 +131,13 @@ GLOBAL_DATUM_INIT(datacore, /datum/datacore, new)
 		dat += "<tr><th colspan=3>Miscellaneous</th></tr>"
 		for(var/name in misc)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[misc[name]]</td><td>[name]</td><td>[isactive[name]]</td></tr>"
+			even = !even
+
+	// beno bois & gorls
+	if(length(xeno) > 0)
+		dat += "<tr><th colspan=3>Xenomorphs</th></tr>"
+		for(var/name in xeno)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[xeno[name]]</td><td>[name]</td><td>[isactive[name]]</td></tr>"
 			even = !even
 
 	dat += "</table>"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -792,11 +792,11 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
 /mob/dead/observer/verb/view_manifest()
 	set category = "Ghost"
-	set name = "View Crew Manifest"
+	set name = "View Game Manifest"
 
-	var/dat = GLOB.datacore.get_manifest()
+	var/dat = GLOB.datacore.get_manifest(ooc = TRUE)
 
-	var/datum/browser/popup = new(src, "manifest", "<div align='center'>Crew Manifest</div>", 370, 420)
+	var/datum/browser/popup = new(src, "manifest", "<div align='center'>Game Manifest</div>", 370, 420)
 	popup.set_content(dat)
 	popup.open(FALSE)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -776,7 +776,7 @@
 	set name = "View Crew Manifest"
 	set category = "IC"
 
-	var/dat = GLOB.datacore.get_manifest()
+	var/dat = GLOB.datacore.get_manifest(ooc = FALSE)
 
 	var/datum/browser/popup = new(src, "manifest", "<div align='center'>Crew Manifest</div>", 370, 420)
 	popup.set_content(dat)

--- a/code/modules/mob/living/silicon/ai/ai_verbs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_verbs.dm
@@ -220,7 +220,7 @@
 	if(incapacitated())
 		return
 
-	var/dat = GLOB.datacore.get_manifest()
+	var/dat = GLOB.datacore.get_manifest(ooc = FALSE)
 
 	var/datum/browser/popup = new(src, "manifest", "<div align='center'>Crew Manifest</div>", 370, 420)
 	popup.set_content(dat)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -229,7 +229,7 @@
 /mob/new_player/proc/view_manifest()
 	var/dat = GLOB.datacore.get_manifest(ooc = TRUE)
 
-	var/datum/browser/popup = new(src, "manifest", "<div align='center'>Crew Manifest</div>", 400, 420)
+	var/datum/browser/popup = new(src, "manifest", "<div align='center'>Game Manifest</div>", 400, 420)
 	popup.set_content(dat)
 	popup.open(FALSE)
 


### PR DESCRIPTION
## About The Pull Request

Players ghosting or in the lobby screen can now see xeno names and castes within the crew manifest, which has been renamed the "Game manifest" when gotten by either type of player.

Also maybe fixed the 'active' tab to display whether or not a player is active and alive at the time the manifest is gotten. Unsure.

## Why It's Good For The Game

Peeps know who's actually around without needing to jump in as an observer.

## Changelog
:cl:Haha26
code: Changed the crew manifest to properly display OOC information when OOC, added xeno tab for manifest with contents gotten from the GLOB list of xeno mobs when gotten from OOC.
/:cl:
