### PR TITLE
Make puppet desc less implied corpses

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -374,7 +374,7 @@
 	action_icon_state = "edible_biomass"
 	desc = "Create edible jelly for hosts."
 	ability_cost = 50
-	cooldown_duration = 20 SECONDS
+	cooldown_duration = 15 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CREATE_EDIBLE_JELLY,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppet/puppet.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppet/puppet.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/xenomorph/puppet
 	caste_base_type = /mob/living/carbon/xenomorph/puppet
 	name = "Puppet"
-	desc = "A reanimated body, crudely pieced together and held in place by an ominous energy tethered to some unknown force."
+	desc = "A humanoid form made of stitched together biomass and resin, tailored carefully, and animated by an unknown force."
 	icon = 'icons/Xeno/castes/puppet.dmi'
 	icon_state = "Puppet Running"
 	health = 250


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Puppeteer is cool, they can make puppets out of thin air but they are implied to be corpses regardless of this, this makes them a bit more accurate and stops calling my puppets crude
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Puppeteers attended a professional knitting class and no longer make crude puppets
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: changed edible jelly cooldown from 20 to 15
fix: made puppet description less corpse obsessed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
