### PR TITLE
Fix Me, LOOC deletion. Subtle and Subtler emotes. Filter LOOC.

### DIFF
--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -15,6 +15,7 @@
 #define MESSAGE_TYPE_WARNING "warning"
 #define MESSAGE_TYPE_DEADCHAT "deadchat"
 #define MESSAGE_TYPE_OOC "ooc"
+#define MESSAGE_TYPE_LOOC "looc"
 #define MESSAGE_TYPE_ADMINPM "adminpm"
 #define MESSAGE_TYPE_COMBAT "combat"
 #define MESSAGE_TYPE_ADMINCHAT "adminchat"

--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -19,6 +19,7 @@
 #define span_danger(str) ("<span class='danger'>" + str + "</span>")
 #define span_deadsay(str) ("<span class='deadsay'>" + str + "</span>")
 #define span_disarm(str) ("<span class='disarm'>" + str + "</span>")
+#define span_emote(str) ("<span class ='emote'>" + str + "</span>")
 #define span_event_announcement(str) ("<span class='event_announcement'>" + str + "</span>")
 #define span_game(str) ("<span class='game'>" + str + "</span>")
 #define span_good(str) ("<span class='good'>" + str + "</span>")

--- a/code/__DEFINES/speech_controller.dm
+++ b/code/__DEFINES/speech_controller.dm
@@ -10,3 +10,7 @@
 #define MESSAGE_INDEX_SPEECH 2
 
 #define CATEGORY_INDEX 3
+
+#define RANGE 4
+
+#define GHOST_VISIBLE 5

--- a/code/controllers/subsystem/speech_controller.dm
+++ b/code/controllers/subsystem/speech_controller.dm
@@ -16,13 +16,13 @@ SUBSYSTEM_DEF(speech_controller)
 	var/list/queued_says_to_execute = list()
 
 ///queues mob_to_queue into our process list so they say(message) near the start of the next tick
-/datum/controller/subsystem/speech_controller/proc/queue_say_for_mob(mob/mob_to_queue, message, message_type)
+/datum/controller/subsystem/speech_controller/proc/queue_say_for_mob(mob/mob_to_queue, message, message_type, range, ghost_visible)
 
 	if(!TICK_CHECK || FOR_ADMINS_IF_BROKE_immediately_execute_all_speech)
-		process_single_say(mob_to_queue, message, message_type)
+		process_single_say(mob_to_queue, message, message_type, range, ghost_visible)
 		return TRUE
 
-	queued_says_to_execute += list(list(mob_to_queue, message, message_type))
+	queued_says_to_execute += list(list(mob_to_queue, message, message_type, range, ghost_visible))
 
 	return TRUE
 
@@ -34,23 +34,25 @@ SUBSYSTEM_DEF(speech_controller)
 
 	for(var/list/say_to_process AS in says_to_process)
 
-		var/mob/mob_to_speak = say_to_process[MOB_INDEX]//index 1 is the mob, 2 is the message, 3 is the message category
+		var/mob/mob_to_speak = say_to_process[MOB_INDEX]//index 1 is the mob, 2 is the message, 3 is the message category, 4 is the range of the message
 		var/message = say_to_process[MESSAGE_INDEX_SPEECH]
 		var/message_category = say_to_process[CATEGORY_INDEX]
+		var/range = say_to_process[RANGE]
+		var/ghost_visible = say_to_process[GHOST_VISIBLE]
 
-		process_single_say(mob_to_speak, message, message_category)
+		process_single_say(mob_to_speak, message, message_category, range, ghost_visible)
 
 ///used in fire() to process a single mobs message through the relevant proc.
 ///only exists so that sleeps in the message pipeline dont cause the whole queue to wait
-/datum/controller/subsystem/speech_controller/proc/process_single_say(mob/mob_to_speak, message, message_category)
+/datum/controller/subsystem/speech_controller/proc/process_single_say(mob/mob_to_speak, message, message_category, range, ghost_visible)
 	set waitfor = FALSE
 
 	switch(message_category)
 		if(SPEECH_CONTROLLER_QUEUE_SAY_VERB)
-			mob_to_speak.say(message)
+			mob_to_speak.say(message, range)
 
 		if(SPEECH_CONTROLLER_QUEUE_WHISPER_VERB)
 			mob_to_speak.whisper(message)
 
 		if(SPEECH_CONTROLLER_QUEUE_EMOTE_VERB)
-			mob_to_speak.emote("me", EMOTE_VISIBLE, message, TRUE)
+			mob_to_speak.emote("me", EMOTE_VISIBLE, message, TRUE, range, ghost_visible)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -79,6 +79,9 @@
 	else
 		msg = replace_pronoun(user, msg) // Only replace pronouns if there is no client
 
+	// Ensure it filters to 'local' within chat tabs
+	msg = span_emote("[msg]")
+
 	// ghost_visible is set to false because the whole thing right above us already displays the message to ghosts. Don't wanna put it in chat twice.
 	if(emote_type == EMOTE_AUDIBLE)
 		user.audible_message(msg, audible_message_flags = EMOTE_MESSAGE, emote_prefix = prefix, hearing_distance = range, ghost_visible = FALSE)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -40,7 +40,7 @@
 	mob_type_ignore_stat_typecache = typecacheof(mob_type_ignore_stat_typecache)
 
 
-/datum/emote/proc/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/proc/run_emote(mob/user, params, type_override, intentional = FALSE, prefix, range = 7, ghost_visible = TRUE)
 	. = TRUE
 	if(!can_run_emote(user, TRUE, intentional))
 		return FALSE
@@ -67,17 +67,23 @@
 		for(var/mob/M AS in GLOB.dead_mob_list)
 			if(!ismob(M) || isnewplayer(M) || !M.client)
 				continue
-			var/T = get_turf(user)
-			if(!(M.client.prefs.toggles_chat & CHAT_GHOSTSIGHT) || (M in viewers(T, null)))
+			var/T1 = get_turf(user)
+			var/T2 = get_turf(M)
+			if((!(M.client.prefs.toggles_chat & CHAT_GHOSTSIGHT) && (get_dist(T1, T2) > range)))
+				continue
+
+			// If this is not meant to be visible to ghosts, make sure not to display it unless the user is an admin
+			if (!(ghost_visible || check_rights_for(M.client, R_ADMIN)))
 				continue
 			M.show_message("[FOLLOW_LINK(M, user)] [dchatmsg]")
 	else
 		msg = replace_pronoun(user, msg) // Only replace pronouns if there is no client
 
+	// ghost_visible is set to false because the whole thing right above us already displays the message to ghosts. Don't wanna put it in chat twice.
 	if(emote_type == EMOTE_AUDIBLE)
-		user.audible_message(msg, audible_message_flags = EMOTE_MESSAGE, emote_prefix = prefix)
+		user.audible_message(msg, audible_message_flags = EMOTE_MESSAGE, emote_prefix = prefix, hearing_distance = range, ghost_visible = FALSE)
 	else
-		user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE, emote_prefix = prefix)
+		user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE, emote_prefix = prefix, vision_distance = range, ghost_visible = FALSE)
 
 /// For handling emote cooldown, return true to allow the emote to happen
 /datum/emote/proc/check_cooldown(mob/user, intentional)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -151,6 +151,7 @@
 				return FALSE
 
 			if(user.client.handle_spam_prevention(message, MUTE_IC))
+				message_admins("Spam prevention triggered by [user] at [ADMIN_VERBOSEJMP(user)]")
 				return FALSE
 
 			if(is_banned_from(user.ckey, "Emote"))
@@ -167,7 +168,6 @@
 					to_chat(user, span_notice("You cannot [key] while unconscious."))
 				if(DEAD)
 					to_chat(user, span_notice("You cannot [key] while dead."))
-
 			return FALSE
 
 		if(flags_emote & EMOTE_RESTRAINT_CHECK)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	))
 
 
-/atom/movable/proc/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+/atom/movable/proc/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null, range = 7)
 	if(!can_speak())
 		return
 
@@ -32,7 +32,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	if(!language)
 		language = get_default_language()
 
-	send_speech(message, 7, src, , spans, message_language = language)
+	send_speech(message, range, src, , spans, message_language = language)
 
 
 /atom/movable/proc/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -941,9 +941,6 @@ GLOBAL_VAR_INIT(automute_on, null)
 	var/weight = SPAM_TRIGGER_WEIGHT_FORMULA(message)
 	total_message_weight += weight
 
-	var/message_cache = total_message_count
-	var/weight_cache = total_message_weight
-
 	if(last_message_time && world.time > last_message_time)
 		last_message_time = 0
 		total_message_count = 0
@@ -951,6 +948,10 @@ GLOBAL_VAR_INIT(automute_on, null)
 
 	else if(!last_message_time)
 		last_message_time = world.time + SPAM_TRIGGER_TIME_PERIOD
+
+	// Having this before the if instead of after requires every long messsage to be sent twice or else have it get locked out.
+	var/message_cache = total_message_count
+	var/weight_cache = total_message_weight
 
 	last_message = message
 
@@ -962,6 +963,8 @@ GLOBAL_VAR_INIT(automute_on, null)
 			to_chat(src, span_danger("You have exceeded the spam filter. An auto-mute was applied."))
 			create_message("note", ckey(key), "SYSTEM", "Automuted due to spam. Last message: '[last_message]'", null, null, FALSE, TRUE, null, FALSE, "Minor")
 			mute(src, mute_type, TRUE)
+		else
+			to_chat(src, span_danger("You have hit the spam filter limit."))
 		return TRUE
 
 	if(warning && GLOB.automute_on && !check_rights(R_ADMIN, FALSE))

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,5 +1,5 @@
 //The code execution of the emote datum is located at code/datums/emotes.dm
-/mob/proc/emote(act, m_type, message, intentional = FALSE)
+/mob/proc/emote(act, m_type, message, intentional = FALSE, range, ghost_visible)
 	act = lowertext(act)
 	var/param = message
 	var/custom_param = findtext(act, " ")
@@ -15,7 +15,7 @@
 	if(!E.check_cooldown(src, intentional))
 		to_chat(src, span_notice("You used that emote too recently."))
 		return
-	E.run_emote(src, param, m_type, intentional)
+	E.run_emote(src, param, m_type, intentional, , range, ghost_visible)
 
 
 /datum/emote/help

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -91,7 +91,7 @@
  * vision_distance (optional) define how many tiles away the message can be seen.
  * ignored_mob (optional) doesn't show any message to a given mob if TRUE.
  */
-/atom/proc/visible_message(message, self_message, blind_message, vision_distance, ignored_mob, visible_message_flags = NONE, emote_prefix)
+/atom/proc/visible_message(message, self_message, blind_message, vision_distance, ignored_mob, visible_message_flags = NONE, emote_prefix, ghost_visible = TRUE)
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
@@ -109,6 +109,10 @@
 			continue
 
 		if(M == ignored_mob)
+			continue
+
+		// Make sure that if this isn't meant to be heard by ghosts it's not.
+		if(!ghost_visible && isdead(M))
 			continue
 
 		var/msg = message
@@ -159,7 +163,7 @@
 // deaf_message (optional) is what deaf people will see.
 // hearing_distance (optional) is the range, how many tiles away the message can be heard.
 
-/mob/audible_message(message, deaf_message, hearing_distance, self_message, audible_message_flags = NONE, emote_prefix)
+/mob/audible_message(message, deaf_message, hearing_distance, self_message, audible_message_flags = NONE, emote_prefix, ghost_visible = TRUE)
 	var/range = 7
 	var/raw_msg = message
 	if(hearing_distance)
@@ -167,6 +171,9 @@
 	if(audible_message_flags & EMOTE_MESSAGE)
 		message = "[emote_prefix]<b>[src]</b> [message]"
 	for(var/mob/M in get_hearers_in_view(range, src))
+		// Make sure that if this isn't meant to be heard by ghosts it's not.
+		if(!ghost_visible && isdead(M))
+			continue
 		var/msg = message
 		if(self_message && M == src)
 			msg = self_message
@@ -182,7 +189,7 @@
  * deaf_message (optional) is what deaf people will see.
  * hearing_distance (optional) is the range, how many tiles away the message can be heard.
  */
-/atom/proc/audible_message(message, deaf_message, hearing_distance, self_message, audible_message_flags = NONE, emote_prefix)
+/atom/proc/audible_message(message, deaf_message, hearing_distance, self_message, audible_message_flags = NONE, emote_prefix, ghost_visible = TRUE)
 	var/range = 7
 	var/raw_msg = message
 	if(hearing_distance)
@@ -190,6 +197,9 @@
 	if(audible_message_flags & EMOTE_MESSAGE)
 		message = "[emote_prefix]<b>[src]</b> [message]"
 	for(var/mob/M in get_hearers_in_view(range, src))
+		// Make sure that if this isn't meant to be heard by ghosts it's not.
+		if(!ghost_visible && isdead(M))
+			continue
 		if(audible_message_flags & EMOTE_MESSAGE && rc_vc_msg_prefs_check(M, audible_message_flags))
 			M.create_chat_message(src, raw_message = raw_msg, runechat_flags = audible_message_flags)
 		M.show_message(message, EMOTE_AUDIBLE, deaf_message, EMOTE_VISIBLE)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -40,6 +40,40 @@
 	say(message, language = language)
 
 
+/mob/living/verb/subtler(message as text)
+
+	set name = "Subtler"
+	set category = "IC"
+	set desc = "Send a 1-tile range message that non-admin ghosts can't see."
+
+	set instant = TRUE
+
+	if(!message)
+		return
+
+	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
+
+	// Italicize it
+	message = "<i>[message]</i>"
+
+	SSspeech_controller.queue_say_for_mob(src, message, SPEECH_CONTROLLER_QUEUE_EMOTE_VERB, range = 1, ghost_visible = FALSE)
+
+
+/mob/living/verb/subtle(message as text)
+	set name = "Subtle"
+	set category = "IC"
+	set desc = "Send a message with a range of 1 tile."
+
+	if(!message)
+		return
+
+	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
+
+	// Italicize it
+	message = "<i>[message]</i>"
+
+	SSspeech_controller.queue_say_for_mob(src, message, SPEECH_CONTROLLER_QUEUE_EMOTE_VERB, range = 1)
+
 /mob/proc/say_dead(message)
 	if(!check_rights(R_ADMIN, FALSE))
 		if(!GLOB.dsay_allowed)

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -69,7 +69,7 @@ a.popt {text-decoration: none;}
 
 .bold, .name, .prefix, .ooc, .looc, .adminooc, .admin, .medal, .yell {font-weight: bold;}
 
-.italic, .italics,  .emote {font-style: italic;}
+.italic, .italics {font-style: italic;}
 
 .highlight {background: yellow;}
 
@@ -147,7 +147,7 @@ a.popt {text-decoration: none;}
 .alert					{color: #ff0000;}
 h1.alert, h2.alert		{color: #000000;}
 
-.emote					{					font-style: italic;}
+.emote					{}
 .selecteddna			{color: #FFFFFF; 	background-color: #001B1B}
 
 .singing				{font-family: "Trebuchet MS", cursive, sans-serif; font-style: italic;}

--- a/tgui/packages/tgui-panel/chat/constants.ts
+++ b/tgui/packages/tgui-panel/chat/constants.ts
@@ -28,6 +28,7 @@ export const MESSAGE_TYPE_INFO = 'info';
 export const MESSAGE_TYPE_WARNING = 'warning';
 export const MESSAGE_TYPE_DEADCHAT = 'deadchat';
 export const MESSAGE_TYPE_OOC = 'ooc';
+export const MESSAGE_TYPE_LOOC = 'looc';
 export const MESSAGE_TYPE_ADMINPM = 'adminpm';
 export const MESSAGE_TYPE_COMBAT = 'combat';
 export const MESSAGE_TYPE_ADMINCHAT = 'adminchat';
@@ -87,7 +88,14 @@ export const MESSAGE_TYPES = [
     name: 'OOC',
     description: 'The bluewall of global OOC messages',
     selector:
-      '.ooc, .colorooc, .looc, .adminooc, .hostooc, .projleadooc, .headcoderooc, .headminooc, .headmentorooc, .trialminooc, .candiminooc, .mentorooc, .maintainerooc, .contributorooc, .otherooc',
+      '.ooc, .colorooc, .adminooc, .hostooc, .projleadooc, .headcoderooc, .headminooc, .headmentorooc, .trialminooc, .candiminooc, .mentorooc, .maintainerooc, .contributorooc, .otherooc',
+  },
+  {
+    type: MESSAGE_TYPE_LOOC,
+    name: 'LOOC',
+    description:
+      'Out-of-character messages from in-view players. Useful for roleplay.',
+    selector: '.looc',
   },
   {
     type: MESSAGE_TYPE_ADMINPM,

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -241,8 +241,7 @@ a.popt {
 /* ADD HERE FOR ITALIC */
 
 .italic,
-.italics,
-.emote {
+.italics {
   font-style: italic;
 }
 
@@ -390,13 +389,11 @@ em {
 }
 
 .say,
+.emote,
 .infoplain {
 }
 .yell {
   font-weight: bold;
-}
-.emote {
-  font-style: italic;
 }
 .singing {
   font-family: 'Trebuchet MS', cursive, sans-serif;


### PR DESCRIPTION
## About The Pull Request

Fixes the spam detection system requiring every long emote to be sent twice in order to properly send. Ensures message_cache and weight_cache are both updated in time for the first time the proc is run, instead of the second.

Adds subtle and subtler verbs! Former is a 1-tile range visible emote, latter is a 1-tile range visible emote that no ghosts (except those with admin permissions) can see.

Lets players filter LOOC separately from OOC when setting up chat tabs.

Fixes filtering by 'local' in chat tabs so that emotes appear in it. Subtle, Subtler, and Me all work with it.

## Why It's Good For The Game

Less frustration during roleplaying!

Ability to lock out voyeurs

Reduce OOC spam for people who are just trying to get roleplay chatlogs.

## Changelog
:cl: Haha26
fix: Fixed can_run_emote in emotes.dm so that the caches that determine spam filtration are always updated in time for the first time the proc is run. Before because of where the value initialization was placed the change would only ever apply the second time a message was sent.
code: Makes sure users are always notified when they've triggered the spam filter. Prevents silent deletion of messages. -- Users should always know why something doesn't send.
admin: Added admin logs when the spam filter is triggered

add: Subtle verb. 1-tile range emote.
add: Subtler verb. 1-tile range emote invisible to non-admin ghosts.
admin: Ensures admins are able to see subtler emotes (when within said 1-tile range if ghost sight is disabled, globally if enabled). All subtle and subtler emotes should be added to the log, also.

code: Separated out LOOC filtration in chat tabs from OOC filtration.

fix: Fixes local filtration in chat tabs to now properly include emotes.
/:cl: