### PR TITLE
Collapsible Flavortexts

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -79,4 +79,5 @@
 
 // Spans that use embedded tgui components:
 // Sorted alphabetically
+#define span_collapsible(title, main_text) ("<span data-component=\"Collapsible\" data-content=\"" + title + "\" class=\"collapsible\">"+ examine_block(main_text) + "</span></span></span>")
 #define span_tooltip(tip, main_text) ("<span data-component=\"Tooltip\" data-content=\"" + tip + "\" class=\"tooltip\">" + main_text + "</span>")

--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -79,5 +79,5 @@
 
 // Spans that use embedded tgui components:
 // Sorted alphabetically
-#define span_collapsible(title, main_text) ("<span data-component=\"Collapsible\" data-content=\"" + title + "\" class=\"collapsible\">"+ examine_block(main_text) + "</span></span></span>")
+#define span_collapsible(title, main_text) ("<span data-component=\"Collapsible\" data-content=\"" + title + "\" class=\"collapsible\">"+ examine_block(main_text) + "</span>")
 #define span_tooltip(tip, main_text) ("<span data-component=\"Tooltip\" data-content=\"" + tip + "\" class=\"tooltip\">" + main_text + "</span>")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -487,7 +487,7 @@
 			if(assigned_squad == H.assigned_squad) //same squad
 				msg += "<a href='?src=[text_ref(src)];squadfireteam=1'>\[Assign to a fireteam.\]</a>\n"
 
-	msg += "[flavor_text]<br>"
+	msg += "\n[span_collapsible("Show / Hide Flavortext", "[flavor_text]")]\n"
 
 	if(HAS_TRAIT(src, TRAIT_HOLLOW))
 		if(isxeno(user))

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -245,7 +245,7 @@
 	. += xeno_caste.caste_desc
 
 	if(xeno_desc)
-		. += "<span class='info'>[xeno_desc]</span>"
+		. += "\n<span class='info'>[span_collapsible("Show / Hide Flavortext", "[xeno_desc]")]</span>"
 
 	if(stat == DEAD)
 		. += "It is DEAD. Kicked the bucket. Off to that great hive in the sky."

--- a/tgui/packages/tgui-panel/chat/renderer.jsx
+++ b/tgui/packages/tgui-panel/chat/renderer.jsx
@@ -11,7 +11,7 @@ import { COMBINE_MAX_MESSAGES, COMBINE_MAX_TIME_WINDOW, IMAGE_RETRY_DELAY, IMAGE
 import { render } from 'react-dom';
 import { canPageAcceptType, createMessage, isSameMessage } from './model';
 import { highlightNode, linkifyNode } from './replaceInTextNode';
-import { Tooltip } from 'tgui/components';
+import { Collapsible, Tooltip } from 'tgui/components';
 
 const logger = createLogger('chatRenderer');
 
@@ -21,6 +21,7 @@ const SCROLL_TRACKING_TOLERANCE = 24;
 
 // List of injectable component names to the actual type
 export const TGUI_CHAT_COMPONENTS = {
+  Collapsible,
   Tooltip,
 };
 

--- a/tgui/packages/tgui/components/Collapsible.tsx
+++ b/tgui/packages/tgui/components/Collapsible.tsx
@@ -4,11 +4,16 @@
  * @license MIT
  */
 
-import { Component } from 'react';
+import { Component, ReactNode } from 'react';
 import { Box } from './Box';
 import { Button } from './Button';
 
-export class Collapsible extends Component {
+type CollapsibleProps = {
+  children?: ReactNode;
+  content: ReactNode;
+};
+
+export class Collapsible extends Component<CollapsibleProps> {
   constructor(props) {
     super(props);
     const { open } = props;


### PR DESCRIPTION
## About The Pull Request

Makes flavortexts for both marines and xenos open up in a separate collapsible component that starts out closed.

## Why It's Good For The Game

Helps reduce chat clutter from flavortexts of ungodly size.

## Changelog
:cl:Haha26
add: Collapsible components are now able to be embedded in tgui chat.
qol: Made flavortexts a collapsible component to reduce chat clutter. Starts closed.
refactor: Refactored Collapsibles to tsx from jsx so that they can be embedded in chat.

code: Renderer.jsx modified to allow Collapsibles. This can be used as a template too add more tgui features in chat. Made heavy use of [chat-embedded-components.md](https://github.com/vitorhks/TerraGov-Marine-Corps-XRF-IV/blob/master/tgui/docs/chat-embedded-components.md).

/:cl: